### PR TITLE
Dt/release notes react native 3 2 2

### DIFF
--- a/docs/Now Ready/Integrate register endpoint.md
+++ b/docs/Now Ready/Integrate register endpoint.md
@@ -63,10 +63,8 @@ If you’re not sure which region your account is in, please contact us at [help
 
 ### API reference
 
+
 The API specification for Wave API can be found [here](https://events-docs.bluedot.io/#operation/postWaveEvents).
----
-pagination_next: null
----
 
 Generate a NowReady URL
 -----------------------

--- a/docs/Version release notes.md
+++ b/docs/Version release notes.md
@@ -7,6 +7,20 @@ pagination_prev: null
 Version Release Notes
 =====================
 
+Release date  Jun 18, 2025
+-------------------------
+
+### Bluedot React Native wrapper 3.2.2
+
+**What's New:**
+
+This release updates the underlying Android Point SDK dependency to version 16.1.1 to resolve a JitPack artifact issue with 16.1.0. No code or functionality has changed.
+
+If you encountered errors with 16.1.0 in Android, please update to 3.2.2.
+
+* * *
+
+
 Release date  Jun 16, 2025
 -------------------------
 


### PR DESCRIPTION
- Add release notes for React native wrapper v3.2.2.
- Fixed typo in Now Ready documentation